### PR TITLE
Editable banner message

### DIFF
--- a/app/assets/stylesheets/components/_hero.scss
+++ b/app/assets/stylesheets/components/_hero.scss
@@ -15,5 +15,8 @@
         color: $white;
       }
     }
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 }

--- a/app/controllers/admin/banner_messages_controller.rb
+++ b/app/controllers/admin/banner_messages_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class BannerMessagesController < Admin::ApplicationController
+    def update
+      banner_message = BannerMessage.instance
+      banner_message.update(resource_params)
+      redirect_to edit_admin_banner_message_path(banner_message), notice: translate_with_resource('update.success')
+    end
+  end
+end

--- a/app/controllers/interventions_controller.rb
+++ b/app/controllers/interventions_controller.rb
@@ -1,4 +1,5 @@
 class InterventionsController < ApplicationController
+  expose :banner_message, -> { BannerMessage.instance.decorate }
   expose :intervention, -> { Intervention.find(params[:id]).decorate }
   expose :interventions, -> { Intervention.all.order(:title).decorate }
 

--- a/app/dashboards/banner_message_dashboard.rb
+++ b/app/dashboards/banner_message_dashboard.rb
@@ -1,0 +1,44 @@
+require 'administrate/base_dashboard'
+
+class BannerMessageDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    title: Field::String,
+    body: Field::SimpleMDEMarkdown
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [
+    :title
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [
+    :title
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    title
+    body
+  ].freeze
+
+  # Overwrite this method to customize how subjects are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(subject)
+  #   "Subject ##{subject.id}"
+  # end
+end

--- a/app/decorators/banner_message_decorator.rb
+++ b/app/decorators/banner_message_decorator.rb
@@ -1,0 +1,11 @@
+class BannerMessageDecorator < ApplicationDecorator
+  delegate_all
+
+  def title
+    h.content_tag(:h1, super, class: 'message')
+  end
+
+  def body
+    parse_markdown(super).html_safe
+  end
+end

--- a/app/models/banner_message.rb
+++ b/app/models/banner_message.rb
@@ -1,0 +1,7 @@
+class BannerMessage < ApplicationRecord
+  validates_inclusion_of :singleton_guard, in: [0]
+
+  def self.instance
+    first_or_create!(singleton_guard: 0)
+  end
+end

--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -1,0 +1,24 @@
+<%#
+# Navigation
+
+This partial is used to display the navigation in Administrate.
+By default, the navigation contains navigation links
+for all resources in the admin dashboard,
+as defined by the routes in the `admin/` namespace
+%>
+
+<nav class="navigation" role="navigation">
+  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+    <% next if resource.resource == 'banner_messages' %>
+    <%= link_to(
+      display_resource_name(resource),
+      [namespace, resource_index_route_key(resource)],
+      class: "navigation__link navigation__link--#{nav_link_state(resource)}"
+    ) %>
+  <% end %>
+  <%= link_to(
+    'Banner Message',
+    edit_admin_banner_message_path(BannerMessage.instance),
+    class: "navigation__link navigation__link--#{nav_link_state('banner_messages')}"
+  ) %>
+</nav>

--- a/app/views/interventions/index.html.haml
+++ b/app/views/interventions/index.html.haml
@@ -1,7 +1,7 @@
 %section.hero
   .hero-wrap
     = banner_message.title
-    .sub
+    %h4.sub
       = banner_message.body
 %section.dashboard
   .container

--- a/app/views/interventions/index.html.haml
+++ b/app/views/interventions/index.html.haml
@@ -1,11 +1,8 @@
 %section.hero
   .hero-wrap
-    %h1.message
-      Better evidence to support better decisions
-    %h4.sub
-      Below you’ll see a dashboard view of the interventions we’ve reviewed  so far, including at-a-glance ratings for overall <a href="/pages/evidence-standards">effectiveness and quality</a> of evidence. You can click through for more detail, including how the intervention works, who it’s for and where it’s been studied.
-    %h4.sub
-      We’ve included some implementation details and some relevant UK contacts and case studies where we can
+    = banner_message.title
+    .sub
+      = banner_message.body
 %section.dashboard
   .container
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     resources :tags
     resources :pages
     resources :users, only: %i[index new create show]
-
+    resources :banner_messages, only: %i[edit update]
     root to: 'interventions#index'
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20181109105703_create_banner_messages.rb
+++ b/db/migrate/20181109105703_create_banner_messages.rb
@@ -1,0 +1,13 @@
+class CreateBannerMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :banner_messages do |t|
+      t.string :title
+      t.text :body
+      t.integer :singleton_guard
+
+      t.timestamps
+    end
+    
+    add_index(:banner_messages, :singleton_guard, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,11 @@ ActiveRecord::Schema.define(version: 2018_11_09_105703) do
     t.index ["intervention_id"], name: "index_contacts_on_intervention_id"
   end
 
+  create_table "evidences", force: :cascade do |t|
+    t.string "title"
+    t.string "description"
+  end
+
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
     t.string "slug", null: false
     t.integer "sluggable_id", null: false
@@ -83,6 +88,7 @@ ActiveRecord::Schema.define(version: 2018_11_09_105703) do
     t.text "summary"
     t.text "what_is_it"
     t.text "who_does_it_work_for"
+    t.text "work_for_intro"
     t.text "when_where_how"
     t.text "outcome_notes"
     t.text "further_resources"
@@ -109,6 +115,7 @@ ActiveRecord::Schema.define(version: 2018_11_09_105703) do
     t.integer "effect"
     t.integer "evidence"
     t.bigint "intervention_id"
+    t.text "evidence_notes"
     t.text "intervention_notes"
     t.index ["intervention_id"], name: "index_outcomes_on_intervention_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_08_182628) do
+ActiveRecord::Schema.define(version: 2018_11_09_105703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,16 +36,20 @@ ActiveRecord::Schema.define(version: 2018_11_08_182628) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "banner_messages", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.integer "singleton_guard"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["singleton_guard"], name: "index_banner_messages_on_singleton_guard", unique: true
+  end
+
   create_table "contacts", force: :cascade do |t|
     t.string "title"
     t.string "url"
     t.bigint "intervention_id"
     t.index ["intervention_id"], name: "index_contacts_on_intervention_id"
-  end
-
-  create_table "evidences", force: :cascade do |t|
-    t.string "title"
-    t.string "description"
   end
 
   create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
@@ -79,7 +83,6 @@ ActiveRecord::Schema.define(version: 2018_11_08_182628) do
     t.text "summary"
     t.text "what_is_it"
     t.text "who_does_it_work_for"
-    t.text "work_for_intro"
     t.text "when_where_how"
     t.text "outcome_notes"
     t.text "further_resources"
@@ -106,7 +109,6 @@ ActiveRecord::Schema.define(version: 2018_11_08_182628) do
     t.integer "effect"
     t.integer "evidence"
     t.bigint "intervention_id"
-    t.text "evidence_notes"
     t.text "intervention_notes"
     t.index ["intervention_id"], name: "index_outcomes_on_intervention_id"
   end

--- a/spec/fabricators/banner_message_fabricator.rb
+++ b/spec/fabricators/banner_message_fabricator.rb
@@ -1,0 +1,5 @@
+Fabricator(:banner_message) do
+  title { FFaker::BaconIpsum.phrase }
+  body  { FFaker::BaconIpsum.paragraph }
+  singleton_guard 0
+end

--- a/spec/features/admin/edit_banner_message.feature
+++ b/spec/features/admin/edit_banner_message.feature
@@ -1,0 +1,9 @@
+@javascript
+Feature: Edit Banner Message
+  
+  Background:
+    Given I am logged in
+  
+  Scenario: Change banner message
+    Given I edit the banner message
+    Then my banner message should be viewable on the homepage

--- a/spec/features/steps/banner_message_steps.rb
+++ b/spec/features/steps/banner_message_steps.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module BannerMessageSteps
+  step 'I edit the banner message' do
+    @banner_message = Fabricate.build(:banner_message)
+
+    click_on 'Banner Message'
+    fill_in 'banner_message_title', with: @banner_message.title
+    within '.markdown-field-wrapper__bannermessage__body' do
+      value = @banner_message.body
+      element = find('.CodeMirror', visible: false)
+      execute_script("arguments[0].CodeMirror.getDoc().setValue('#{value}')", element)
+    end
+    first('input[name="commit"]').click
+  end
+
+  step 'my banner message should be viewable on the homepage' do
+    visit '/'
+    expect(page).to have_content(@banner_message.title)
+    expect(page).to have_content(@banner_message.body)
+  end
+end
+
+RSpec.configure { |c| c.include BannerMessageSteps }

--- a/spec/models/banner_message_spec.rb
+++ b/spec/models/banner_message_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe BannerMessage, type: :model do
+  describe '#instance' do
+    let(:instance) { described_class.instance }
+    let(:banner_message) { Fabricate(:banner_message) }
+
+    it 'creates a BannerMessage if none exists' do
+      expect(instance).to be_a(BannerMessage)
+    end
+
+    it 'returns the message' do
+      banner_message
+      expect(instance).to eq(banner_message)
+    end
+  end
+end


### PR DESCRIPTION
This allows users to edit the banner message in a similar way to interventions (but not create new ones). Styling may need looking at as the body is now paragraphs, not h4s